### PR TITLE
Fix Node.js version requirement in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
Update Node.js version from 18 to 20 to meet Next.js 16 requirement (>=20.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)